### PR TITLE
add gitleaks reusable workflow

### DIFF
--- a/.github/workflows/call-run-gitleaks.yml
+++ b/.github/workflows/call-run-gitleaks.yml
@@ -1,0 +1,15 @@
+name: Call Run GitLeaks
+# Learn more about GitLeaks: https://gitleaks.io/
+# Learn more about GitHub Actions: https://docs.github.com/en/actions
+
+# on specifies the build triggers. See more info at 
+# https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
+# The default build trigger is to run the action on every push and pull request, for any branch
+on: [push, pull_request]
+# This workflow calls a reusable github action located at 
+# https://github.com/nmfs-ost/admin/blob/main/.github/workflows/run-gitleaks.yml
+# Learn more about reusable actions: https://docs.github.com/en/actions/using-workflows/reusing-workflows
+jobs:
+  call-workflow:
+    uses: nmfs-ost/admin/.github/workflows/run-gitleaks.yml@main
+    secrets: inherit

--- a/.github/workflows/run-gitleaks.yml
+++ b/.github/workflows/run-gitleaks.yml
@@ -1,0 +1,12 @@
+name: Run gitleaks
+on:
+  workflow_call:
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+      - name: gitleaks-action
+        uses: gitleaks/gitleaks-action@v1.6.0


### PR DESCRIPTION
Addresses #7.

@csbrown-noaa could you test out if this allows you to use the reusable workflow in a public repository? To test, you can change the reference to the reusable workflow in your workflow from
```
uses: nmfs-ost/admin/.github/workflows/run-gitleaks.yml@main
```
to
```
uses: nmfs-ost/.github/.github/workflows/run-gitleaks.yml@gitleaks_workflow
```

Once we verify, this can be merged into main and the following reference should be used:
```
uses: nmfs-ost/.github/.github/workflows/run-gitleaks.yml@main
```